### PR TITLE
first draft of Kubernetes YAML for Mozillians

### DIFF
--- a/cluster-conf/apps/mozillians/broker-deployment.yaml
+++ b/cluster-conf/apps/mozillians/broker-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: broker
+  name: broker
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: broker
+    spec:
+      containers:
+      - image: redis:3
+        name: broker
+        ports:
+        - containerPort: 6379
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/cluster-conf/apps/mozillians/broker-service.yaml
+++ b/cluster-conf/apps/mozillians/broker-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: broker
+  name: broker
+  namespace: mozillians-dev
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 6379
+    targetPort: 0
+  selector:
+    io.kompose.service: broker
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/celery-claim0-persistentvolumeclaim.yaml
+++ b/cluster-conf/apps/mozillians/celery-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: celery-claim0
+  name: celery-claim0
+  namespace: mozillians-dev
+spec:
+  storageClassName: mozillians
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/cluster-conf/apps/mozillians/celery-deployment.yaml
+++ b/cluster-conf/apps/mozillians/celery-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: celery
+  name: celery
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: celery
+    spec:
+      containers:
+      - args:
+        - /code/bin/run-celery.sh
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+        image: danielhartnell/mozillians:1.0.1
+        name: celery
+        resources: {}
+      restartPolicy: Always
+      volumes:
+      - name: celery-claim0
+        persistentVolumeClaim:
+          claimName: celery-claim0
+status: {}

--- a/cluster-conf/apps/mozillians/celery-service.yaml
+++ b/cluster-conf/apps/mozillians/celery-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: celery
+  name: celery
+  namespace: mozillians-dev
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 55555
+    targetPort: 0
+  selector:
+    io.kompose.service: celery
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/db-claim1-persistentvolumeclaim.yaml
+++ b/cluster-conf/apps/mozillians/db-claim1-persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: db-claim1
+  name: db-claim1
+  namespace: mozillians-dev
+spec:
+  storageClassName: mozillians
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/cluster-conf/apps/mozillians/db-deployment.yaml
+++ b/cluster-conf/apps/mozillians/db-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: db
+  name: db
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: db
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_DATABASE
+          value: mozillians
+        - name: MYSQL_PASSWORD
+          value: replace
+        - name: MYSQL_ROOT_PASSWORD
+          value: replace
+        - name: MYSQL_USER
+          value: mozillians
+        image: mariadb:10.2
+        name: db
+        ports:
+        - containerPort: 3600
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/cluster-conf/apps/mozillians/db-service.yaml
+++ b/cluster-conf/apps/mozillians/db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: db
+  name: db
+  namespace: mozillians-dev
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 3306
+    targetPort: 3306
+  selector:
+    io.kompose.service: db
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/es-deployment.yaml
+++ b/cluster-conf/apps/mozillians/es-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: es
+  name: es
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: es
+    spec:
+      containers:
+      - image: elasticsearch:2.4.5
+        name: es
+        ports:
+        - containerPort: 9200
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/cluster-conf/apps/mozillians/es-service.yaml
+++ b/cluster-conf/apps/mozillians/es-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: es
+  name: es
+  namespace: mozillians-dev
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 9200
+    targetPort: 9200
+  selector:
+    io.kompose.service: es
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/flower-claim0-persistentvolumeclaim.yaml
+++ b/cluster-conf/apps/mozillians/flower-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: flower-claim0
+  name: flower-claim0
+  namespace: mozillians-dev
+spec:
+  storageClassName: mozillians
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/cluster-conf/apps/mozillians/flower-deployment.yaml
+++ b/cluster-conf/apps/mozillians/flower-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: flowersvc
+  name: flowersvc
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: flowersvc
+    spec:
+      containers:
+      - name: flowersvc
+        image: danielhartnell/mozillians:1.0.1
+        command: ["flower"]
+        args: ["-A", "mozillians", "--address=0.0.0.0", "--port=5555"]
+        ports:
+        - containerPort: 5555
+        resources: {}
+      restartPolicy: Always
+      volumes:
+      - name: flower-claim0
+        persistentVolumeClaim:
+          claimName: flower-claim0
+status: {}

--- a/cluster-conf/apps/mozillians/flower-service.yaml
+++ b/cluster-conf/apps/mozillians/flower-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: flowersvc
+  name: flowersvc
+  namespace: mozillians-dev
+spec:
+  ports:
+  - name: "5555"
+    port: 5555
+    targetPort: 5555
+  selector:
+    io.kompose.service: flowersvc
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/mariadb-volume-persistentvolumeclaim.yaml
+++ b/cluster-conf/apps/mozillians/mariadb-volume-persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mariadb-volume
+  name: mariadb-volume
+  namespace: mozillians-dev
+spec:
+  storageClassName: mozillians
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/cluster-conf/apps/mozillians/memcached-deployment.yaml
+++ b/cluster-conf/apps/mozillians/memcached-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached
+  name: memcached
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: memcached
+    spec:
+      containers:
+      - image: memcached
+        name: memcached
+        ports:
+        - containerPort: 11211
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/cluster-conf/apps/mozillians/memcached-service.yaml
+++ b/cluster-conf/apps/mozillians/memcached-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached
+  name: memcached
+  namespace: mozillians-dev
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 11211
+    targetPort: 0
+  selector:
+    io.kompose.service: memcached
+status:
+  loadBalancer: {}

--- a/cluster-conf/apps/mozillians/web-claim0-persistentvolumeclaim.yaml
+++ b/cluster-conf/apps/mozillians/web-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: web-claim0
+  name: web-claim0
+  namespace: mozillians-dev
+spec:
+  storageClassName: mozillians
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/cluster-conf/apps/mozillians/web-deployment.yaml
+++ b/cluster-conf/apps/mozillians/web-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: web
+  name: web
+  namespace: mozillians-dev
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: web
+    spec:
+      containers:
+      - image: danielhartnell/mozillians:1.0.1
+        name: web
+        ports:
+        - containerPort: 8000
+        resources: {}
+        stdin: true
+        tty: true
+      restartPolicy: Always
+      volumes:
+      - name: web-claim0
+        persistentVolumeClaim:
+          claimName: web-claim0
+status: {}

--- a/cluster-conf/apps/mozillians/web-service.yaml
+++ b/cluster-conf/apps/mozillians/web-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: ./kompose convert
+    kompose.version: ""
+  creationTimestamp: null
+  labels:
+    io.kompose.service: web
+  name: web
+  namespace: mozillians-dev
+spec:
+  ports:
+  - name: "8000"
+    port: 8000
+    targetPort: 8000
+  selector:
+    io.kompose.service: web
+status:
+  loadBalancer: {}


### PR DESCRIPTION
I found a tool called `kompose` which will allow you to convert a `docker-compose.yml` file into Kubernetes YAML. This will need to be cleaned up but, right now, it does allow us to run a development version of the site in our cluster. Once the Mozillians supporting infrastructure (Elasticsearch, Elasticache, etc.) is available, this can be modified to use those staging or production resources.