### PR TITLE
adds pipelines for auth0-deploy

### DIFF
--- a/infrastructure/auth0-deploy.tf
+++ b/infrastructure/auth0-deploy.tf
@@ -13,17 +13,8 @@ module "auth0-deploy-ci-stage" {
   environment    = "stage"
   github_repo    = "https://github.com/mozilla-iam/auth0-deploy"
   github_branch  = "master"
-  enable_webhook = "false"
+  enable_webhook = "true"
   enable_ecr     = "false"
+  build_image    = "aws/codebuild/python:3.6.5"
 }
 
-module "auth0-deploy-ci-prod" {
-  source = "./modules/ci"
-
-  project_name   = "auth0-deploy"
-  environment    = "prod"
-  github_repo    = "https://github.com/mozilla-iam/auth0-deploy"
-  github_branch  = "production"
-  enable_webhook = "false"
-  enable_ecr     = "false"
-}

--- a/infrastructure/auth0-deploy.tf
+++ b/infrastructure/auth0-deploy.tf
@@ -1,0 +1,29 @@
+#---
+# Create CI pipeline:
+#   - CodeBuild and ECR
+#   - Uses OAuth to create webhooks in GitHub repositories
+#
+# https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-authentication.html
+#---
+
+module "auth0-deploy-ci-stage" {
+  source = "./modules/ci"
+
+  project_name   = "auth0-deploy"
+  environment    = "stage"
+  github_repo    = "https://github.com/mozilla-iam/auth0-deploy"
+  github_branch  = "master"
+  enable_webhook = "false"
+  enable_ecr     = "false"
+}
+
+module "auth0-deploy-ci-prod" {
+  source = "./modules/ci"
+
+  project_name   = "auth0-deploy"
+  environment    = "prod"
+  github_repo    = "https://github.com/mozilla-iam/auth0-deploy"
+  github_branch  = "production"
+  enable_webhook = "false"
+  enable_ecr     = "false"
+}

--- a/infrastructure/modules/ci/variables.tf
+++ b/infrastructure/modules/ci/variables.tf
@@ -2,3 +2,11 @@ variable "github_branch" {}
 variable "github_repo" {}
 variable "project_name" {}
 variable "environment" {}
+
+variable "enable_webhook" {
+  default = "true"
+}
+
+variable "enable_ecr" {
+  default = "true"
+}

--- a/infrastructure/modules/ci/variables.tf
+++ b/infrastructure/modules/ci/variables.tf
@@ -10,3 +10,7 @@ variable "enable_webhook" {
 variable "enable_ecr" {
   default = "true"
 }
+
+variable "build_image" {
+  default = "aws/codebuild/docker:17.09.0"
+}

--- a/infrastructure/sso-dashboard.tf
+++ b/infrastructure/sso-dashboard.tf
@@ -1,0 +1,27 @@
+#---
+# Create CI pipeline:
+#   - CodeBuild and ECR
+#   - Uses OAuth to create webhooks in GitHub repositories
+#
+# https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-authentication.html
+#---
+
+module "sso-dashboard-ci-stage" {
+  source = "./modules/ci"
+
+  project_name   = "sso-dashboard"
+  environment    = "stage"
+  github_repo    = "https://github.com/mozilla-iam/sso-dashboard"
+  github_branch  = "master"
+  enable_webhook = "true"
+}
+
+module "sso-dashboard-ci-prod" {
+  source = "./modules/ci"
+
+  project_name   = "sso-dashboard"
+  environment    = "prod"
+  github_repo    = "https://github.com/mozilla-iam/sso-dashboard"
+  github_branch  = "production"
+  enable_webhook = "true"
+}


### PR DESCRIPTION
This requires the following:
 - Add boolean to enable / disable ECR (auth0-deploy does not use it)
 - Conditionally set environment variable for ECR repo in CodeBuild
 - Add boolean to enable / disable webhooks

Regarding the webhooks: the CodeBuild OAuth grant needs changes to allow the ability to manage webhooks in the source repository.