### PR TITLE
upgrading version of Elasticsearch

### DIFF
--- a/infrastructure/modules/mozillians/main.tf
+++ b/infrastructure/modules/mozillians/main.tf
@@ -202,7 +202,7 @@ resource "aws_db_instance" "mysql-mozillians-db" {
 
 resource "aws_elasticsearch_domain" "mozillians-es" {
   domain_name           = "mozillians-shared-es-${var.environment}"
-  elasticsearch_version = "2.3"
+  elasticsearch_version = "5.6"
 
   ebs_options {
     ebs_enabled = true


### PR DESCRIPTION
This should resolve the issues in https://github.com/mozilla-iam/eks-deployment/issues/66. Eventually I discovered that the ES version used was 2.3 in the Terraform that I copied into this repository. I think that the limited ES features at that level (including no reindex support) result in the behavior described in that issue.