### PR TITLE
reducing memory resource constraints to address node failure

### DIFF
--- a/cluster-conf/apps/sso-dashboard/dev-deployment.yml
+++ b/cluster-conf/apps/sso-dashboard/dev-deployment.yml
@@ -32,10 +32,10 @@ spec:
           - containerPort: 8000
           resources:
             requests:
-              memory: "768Mi"
+              memory: "200Mi"
               cpu: "250m"
             limits:
-              memory: "1024Mi"
+              memory: "200Mi"
               cpu: "500m"
           env:
             - name: AWS_DEFAULT_REGION


### PR DESCRIPTION
I provided nearly 25% of the available memory to a single pod that has very little traffic. I think reducing the memory limits will allow the node to return to a healthy state.

<img width="686" alt="image" src="https://user-images.githubusercontent.com/322152/46562960-a94e9200-c8b3-11e8-9203-4b59273f27ca.png">
