### PR TITLE
adds StorageClass for Grafana

### DIFF
--- a/cluster-conf/monitoring/25-grafana-deployment.yaml
+++ b/cluster-conf/monitoring/25-grafana-deployment.yaml
@@ -4,12 +4,21 @@ metadata:
   namespace: monitoring
   name: grafana-persistent-storage
 spec:
-  storageClassName: standard
+  storageClassName: grafana-storage
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: grafana-storage
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+allowVolumeExpansion: true
 ---
 apiVersion: apps/v1beta2
 kind: Deployment


### PR DESCRIPTION
Setting `storageClassName: standard` in the `PersistentVolumeClaim` put that PVC in a pending state for about 30 days. I manually created this new `StorageClass` and I'm checking in that change now.

Interestingly, it looks like this might have prevented the cluster autoscaler from adding new nodes (or at least increasing the number of pods for Grafana). I only found this because the cluster autoscaler logs showed that it would not matter if it scaled up the number of nodes because this pod had an unbounded persistent volume claim. Looking into that showed the pending state. Adding the `StorageClass` and updating the `storageClassName` resolved that issue.