### PR TITLE
pin Terraform client to 0.11.x

### DIFF
--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -21,6 +21,7 @@ provider "http" {}
 # Shared state configuration
 
 terraform {
+  required_version = "~> 0.11"
   backend "s3" {
     bucket = "eks-terraform-shared-state"
     key    = "iam-eks-cluster/development/terraform.tfstate"


### PR DESCRIPTION
Straightforward change. Just wanted to make sure the Terraform contributors are using warned if they aren't using the same minor release.