### PR TITLE
replaces variable prompt with SSM lookup for pass

### DIFF
--- a/infrastructure/modules/mozillians/main.tf
+++ b/infrastructure/modules/mozillians/main.tf
@@ -269,7 +269,7 @@ resource "aws_elasticsearch_domain" "mozillians-es" {
       "Action": [
         "es:*"
       ],
-      "Resource": "arn:aws:es:us-west-2:320464205386:domain/mozillians-shared-es-stage/*"
+      "Resource": "arn:aws:es:us-west-2:${data.aws_caller_identity.current.account_id}:domain/mozillians-shared-es-stage/*"
     }
   ]
 }

--- a/infrastructure/modules/mozillians/variables.tf
+++ b/infrastructure/modules/mozillians/variables.tf
@@ -4,5 +4,4 @@ variable "elasticache_redis_instance_size" {}
 variable "elasticache_memcached_instance_size" {}
 variable "cis_publisher_role_arn" {}
 variable "rds_instance_class" {}
-variable "mysql-mozillians-db_password" {}
 variable "k8s_source_security_group" {}

--- a/infrastructure/mozillians.tf
+++ b/infrastructure/mozillians.tf
@@ -1,5 +1,3 @@
-variable "mysql-mozillians-db_password" {}
-
 #---
 # Create AWS resources for Mozillians
 #---
@@ -19,7 +17,6 @@ module "mozillians-staging" {
   elasticache_memcached_instance_size = "cache.t2.micro"
   rds_instance_class                  = "db.t2.small"
   cis_publisher_role_arn              = "arn:aws:iam::656532927350:role/CISPublisherRole"
-  mysql-mozillians-db_password        = "${var.mysql-mozillians-db_password}"
   k8s_source_security_group           = "${module.eks-production-01.node-security-group}"
 }
 
@@ -37,7 +34,6 @@ module "mozillians-production" {
   elasticache_memcached_instance_size = "cache.t2.micro"
   rds_instance_class                  = "db.t2.medium"
   cis_publisher_role_arn              = "arn:aws:iam::371522382791:role/CISPublisherRole"
-  mysql-mozillians-db_password        = "${var.mysql-mozillians-db_password}"
   k8s_source_security_group           = "${module.eks-production-01.node-security-group}"
 }
 


### PR DESCRIPTION
Some additional changes are brought in with this PR:

- Downgrade Elasticsearch to match prod Mozillians
- Use AWS-provided access policy for Elasticsearch
- Add Mozillians S3 buckets
- Push all IAM access into one role with inline policies