### PR TITLE
adding role for Keel pod to assume for ECR polling

### DIFF
--- a/cluster-conf/keel/deployment-rbac.yaml
+++ b/cluster-conf/keel/deployment-rbac.yaml
@@ -110,6 +110,8 @@ spec:
       labels:
         app: keel
         release: keel
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::320464205386:role/terraform-kubernetes-production-01-node-keel
     spec:
       serviceAccountName: keel
       containers:
@@ -129,6 +131,8 @@ spec:
             # Enable insecure registries
             - name: INSECURE_REGISTRY
               value: "true"
+            - name: AWS_REGION
+              value: "us-west-2"
           ports:
             - containerPort: 9300
           livenessProbe:

--- a/infrastructure/modules/eks-cluster/eks-worker-nodes.tf
+++ b/infrastructure/modules/eks-cluster/eks-worker-nodes.tf
@@ -45,6 +45,25 @@ resource "aws_iam_role" "cluster-autoscaler" {
 POLICY
 }
 
+resource "aws_iam_role" "keel" {
+  name = "terraform-${var.cluster-name}-node-keel"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.demo-node.arn}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
 resource "aws_iam_role_policy" "cluster-autoscaler-policy" {
   name = "terraform-${var.cluster-name}-node-ClusterAutoscaler"
   role = "${aws_iam_role.cluster-autoscaler.id}"
@@ -65,6 +84,31 @@ resource "aws_iam_role_policy" "cluster-autoscaler-policy" {
             "Resource": "*"
         }
     ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "keel-policy" {
+  name = "terraform-${var.cluster-name}-node-keel"
+  role = "${aws_iam_role.keel.id}"
+
+  policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Effect": "Allow",
+		"Action": [
+			"ecr:GetAuthorizationToken",
+			"ecr:BatchCheckLayerAvailability",
+			"ecr:GetDownloadUrlForLayer",
+			"ecr:GetRepositoryPolicy",
+			"ecr:DescribeRepositories",
+			"ecr:ListImages",
+			"ecr:DescribeImages",
+			"ecr:BatchGetImage"
+		],
+		"Resource": "*"
+	}]
 }
 EOF
 }


### PR DESCRIPTION
This change was made a while back but I did not push it to GitHub. This provides Keel with the access it needs to poll ECR for new images.