### PR TITLE
adds support for cluster node rolling updates

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,8 +8,8 @@ module "eks-development-01" {
   environment               = "development"
   region                    = "us-west-2"
   instance-type             = "c4.large"
-  instance-desired-capacity = 4
-  instance-max              = 4
+  instance-desired-capacity = 3
+  instance-max              = 5
   instance-min              = 2
 }
 
@@ -19,7 +19,7 @@ module "eks-production-01" {
   environment               = "production"
   region                    = "us-west-2"
   instance-type             = "c4.large"
-  instance-desired-capacity = 4
+  instance-desired-capacity = 5
   instance-max              = 10
   instance-min              = 4
   create-resource-vpc       = true


### PR DESCRIPTION
I do not love this solution but it works well enough. CloudFormation supports rolling updates of nodes in an autoscaling group. It can batch changes and add a delay before moving onto new nodes. Terraform does not support this today so I'm using Terraform to manage a CloudFormation stack. With this change, we can update the launch configuration and avoid downtime by replacing the nodes in the autoscaling group one at a time. There is a 3 minute delay to allow time for the new nodes to boot and join the cluster. In the future, we should add a health check to make sure that nodes successfully join the cluster.