### PR TITLE
Upgrade cert manager

### DIFF
--- a/cluster-conf/ingress/cert-manager/with-rbac.yaml
+++ b/cluster-conf/ingress/cert-manager/with-rbac.yaml
@@ -5,6 +5,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "cert-manager"
+  labels:
+    name: "cert-manager"
+    certmanager.k8s.io/disable-validation: "true"
 
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
@@ -15,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -24,9 +27,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -46,9 +51,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -64,9 +71,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +93,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -104,7 +113,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -124,7 +133,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.4
+    chart: cert-manager-v0.5.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -143,8 +152,8 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:canary"
-          imagePullPolicy: Always
+          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
+          imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)

--- a/cluster-conf/ingress/cert-manager/with-rbac.yaml
+++ b/cluster-conf/ingress/cert-manager/with-rbac.yaml
@@ -98,7 +98,7 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers"]
+    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]


### PR DESCRIPTION
This updates to the latest 0.5.0 release of cert-manager. I'm currently seeing some errors regarding permissions:

```
...Failed to list *v1alpha1.Challenge: challenges.certmanager.k8s.io is forbidden...
```

In the master branch, they added "orders" and "challenges" to the ClusterRole resources so I'm including that as well.