### PR TITLE
bring git in sync with Terraform current Terraform state

### DIFF
--- a/infrastructure/dino-park-resources.tf
+++ b/infrastructure/dino-park-resources.tf
@@ -8,8 +8,13 @@ data "aws_subnet_ids" "all" {
   vpc_id = "${module.resource-vpc-production.vpc-id}"
 }
 
+data "aws_security_group" "resource-vpc" {
+  vpc_id = "${module.resource-vpc-production.vpc-id}"
+  name   = "default"
+}
+
 resource "aws_elasticsearch_domain" "dinopark-es" {
-  domain_name           = "mozillians-shared-es-dinopark"
+  domain_name           = "mozillians-es-dinopark"
   elasticsearch_version = "6.3"
 
   ebs_options {
@@ -26,7 +31,7 @@ resource "aws_elasticsearch_domain" "dinopark-es" {
   }
 
   snapshot_options {
-    automated_snapshot_start_hour = 23
+    automated_snapshot_start_hour = 17
   }
 
   vpc_options {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "eks-development-01" {
   environment               = "development"
   region                    = "us-west-2"
   instance-type             = "c4.large"
-  instance-desired-capacity = 3
+  instance-desired-capacity = 4
   instance-max              = 5
   instance-min              = 2
 }

--- a/infrastructure/modules/mozillians/main.tf
+++ b/infrastructure/modules/mozillians/main.tf
@@ -128,7 +128,7 @@ resource "aws_security_group_rule" "mozillians-mysql-ingress" {
   security_group_id        = "${aws_security_group.mozillians-mysql.id}"
 }
 
-resource "aws_security_group_rule" "mozillians-mysql-ingress-additions" {
+resource "aws_security_group_rule" "mozillians-mysql-ingress-addition" {
   type                     = "ingress"
   from_port                = 3306
   to_port                  = 3306

--- a/infrastructure/mozillians.tf
+++ b/infrastructure/mozillians.tf
@@ -8,6 +8,18 @@ resource "aws_iam_service_linked_role" "es" {
   aws_service_name = "es.amazonaws.com"
 }
 
+module "mozillians-dino-park-staging" {
+  source = "./modules/mozillians"
+
+  environment                         = "dino"
+  vpc_id                              = "${module.resource-vpc-production.vpc-id}"
+  elasticache_redis_instance_size     = "cache.t2.micro"
+  elasticache_memcached_instance_size = "cache.t2.micro"
+  rds_instance_class                  = "db.t2.small"
+  cis_publisher_role_arn              = "arn:aws:iam::656532927350:role/CISPublisherRole"
+  k8s_source_security_group           = "${module.eks-production-01.node-security-group}"
+}
+
 module "mozillians-staging" {
   source = "./modules/mozillians"
 


### PR DESCRIPTION
This brings in several unrelated changes.

- Increases development cluster worker node count
- Adds Elasticsearch for Dino Park
- Adds Dino Park Mozillians resources