### PR TITLE
disable webhook for Mozillians CI

### DIFF
--- a/infrastructure/mozillians.tf
+++ b/infrastructure/mozillians.tf
@@ -60,17 +60,19 @@ module "mozillians-production" {
 module "mozillians-ci-stage" {
   source = "./modules/ci"
 
-  project_name  = "mozillians"
-  environment   = "stage"
-  github_repo   = "https://github.com/danielhartnell/mozillians"
-  github_branch = "^master$"
+  project_name   = "mozillians"
+  environment    = "stage"
+  github_repo    = "https://github.com/danielhartnell/mozillians"
+  github_branch  = "^master$"
+  enable_webhook = "false"
 }
 
 module "mozillians-ci-prod" {
   source = "./modules/ci"
 
-  project_name  = "mozillians"
-  environment   = "prod"
-  github_repo   = "https://github.com/danielhartnell/mozillians"
-  github_branch = "^production$"
+  project_name   = "mozillians"
+  environment    = "prod"
+  github_repo    = "https://github.com/danielhartnell/mozillians"
+  github_branch  = "^production$"
+  enable_webhook = "false"
 }


### PR DESCRIPTION
Terraform apply will fail as long as the default is set to true. Because Mozillians is in mozilla rather than mozilla-iam, I need to find a solution to grant OAuth access. I suspect I'll probably exclude webhooks from this CI configuration, manually create one with the AWS CLI and request that the admin sets it up. This is not perfect but it is probably sufficient for this one site as an exception.