### PR TITLE
adds option to login to Grafana with Auth0 / OIDC

### DIFF
--- a/cluster-conf/monitoring/25-grafana-deployment.yaml
+++ b/cluster-conf/monitoring/25-grafana-deployment.yaml
@@ -40,6 +40,38 @@ spec:
       containers:
       - image: grafana/grafana:5.3.1
         name: grafana
+        env:
+        - name: GF_AUTH_GENERIC_OAUTH_NAME
+          value: Auth0
+        - name: GF_AUTH_GENERIC_OAUTH_ENABLED
+          value: "true"
+        - name: GF_AUTH_GENERIC_OAUTH_SCOPES
+          value: "openid profile email"
+        - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: grafana-oidc
+              key: client_id
+        - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: grafana-oidc
+              key: client_secret
+        - name: GF_AUTH_GENERIC_OAUTH_AUTH_URL
+          valueFrom:
+            secretKeyRef:
+              name: grafana-oidc
+              key: auth_url
+        - name: GF_AUTH_GENERIC_OAUTH_TOKEN_URL
+          valueFrom:
+            secretKeyRef:
+              name: grafana-oidc
+              key: token_url
+        - name: GF_AUTH_GENERIC_OAUTH_API_URL
+          valueFrom:
+            secretKeyRef:
+              name: grafana-oidc
+              key: api_url
         ports:
         - containerPort: 3000
           name: http


### PR DESCRIPTION
This should not impact the existing basic auth login. Once we have tested it and confirmed that the right users have access, we can disable the basic auth option and force Auth0 logins.