### PR TITLE
Flux fails trying to apply this because the namespace does not exist

### DIFF
--- a/cluster-conf/apps/sso-dashboard/stage/ssodashboard.yaml
+++ b/cluster-conf/apps/sso-dashboard/stage/ssodashboard.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sso-dashboard
     keel.sh/trigger: poll
     keel.sh/policy: force
-  namespace: development
+  namespace: dev
 spec:
   replicas: 3
   selector:
@@ -46,7 +46,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sso-dashboard
-  namespace: development
+  namespace: dev
 spec:
   ports:
     - port: 8000
@@ -63,7 +63,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-production
   name: sso-dashboard
-  namespace: development
+  namespace: dev
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
@danielhartnell Working on cleaning up all the errors happening across the cluster.

The `development` namespace doesn't exist, but `dev` does exist. Don't know if you want to deploy that in another namespace, create one for sso, bring the that code out of this repo...
So, just wanted to bring awareness and you can decide on how to proceed!