### PR TITLE
Upgrade Graylog and switch to new Graylog org on Dockerhub

### DIFF
--- a/cluster-conf/graylog_stack/10-graylog-master.yml
+++ b/cluster-conf/graylog_stack/10-graylog-master.yml
@@ -29,7 +29,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: graylog-master
-          image: graylog2/server:2.4.6-1
+          image: graylog/graylog:2.5.1-2
           env:
           - name: GRAYLOG_PASSWORD_SECRET
             valueFrom:


### PR DESCRIPTION
Graylog has released a new minor version fixing some bugs and adding some features, you can read more about it here: http://docs.graylog.org/en/2.5/pages/changelog.html.

Also, they deprecated the old Organization (named "graylog2") in DockerHub in favor of "graylog". Using this one from now on.

I've tested the changes in the old prod cluster and I couldn't find any problem. Just applying the statefulset will delete the pod and create a new one with the newer version.