### PR TITLE
Add MongoDB metrics exporter, ServiceMonitor and Prometheus Alert rules.

### DIFF
--- a/cluster-conf/graylog/26-mongodb-metrics-exporter.yaml
+++ b/cluster-conf/graylog/26-mongodb-metrics-exporter.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: graylog-mongodb-metrics-exporter
+  name: graylog-mongodb-metrics-exporter
+  namespace: logging
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: graylog-mongodb-metrics-exporter
+  template:
+    metadata:
+      labels:
+        k8s-app: graylog-mongodb-metrics-exporter
+    spec:
+      containers:
+      - image: thesmoothoperator/mongodb-prometheus-exporter:0.6.2
+        name: graylog-mongodb-metrics-exporter
+        command:
+          - /bin/mongodb_exporter
+          - -mongodb.uri=mongodb://mongo-graylog-0.mongo-graylog.logging.svc.cluster.local:27017,mongo-graylog-1.mongo-graylog.logging.svc.cluster.local:27017,mongo-graylog-2.mongo-graylog.logging.svc.cluster.local:27017
+        ports:
+        - containerPort: 9216
+          name: metrics
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graylog-mongodb-metrics-exporter
+  namespace: logging
+  labels:
+    k8s-app: graylog-mongodb-metrics-exporter
+spec:
+  ports:
+  - name: metrics
+    port: 9216
+    targetPort: metrics
+  selector:
+    k8s-app: graylog-mongodb-metrics-exporter
+  clusterIP: None
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: graylog-mongodb-metrics-exporter
+  name: graylog-mongodb-metrics-exporter
+  namespace: logging
+spec:
+  endpoints:
+  - interval: 120s
+  jobLabel: graylog-mongodb-metrics
+  selector:
+    matchLabels:
+      k8s-app: graylog-mongodb-metrics-exporter

--- a/cluster-conf/monitoring/rules/mongodb-rules.yml
+++ b/cluster-conf/monitoring/rules/mongodb-rules.yml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-general
+    role: alert-rules
+  name: mongodb-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: mongodb.rules
+    rules:
+    - alert: MongoDB_replicaSet_missing_members
+      annotations:
+        message: 'MongoDB replicaSet has less than 3 members'
+      expr: |
+        mongodb_mongod_replset_number_of_members < 3
+      for: 5m
+      labels:
+        severity: critical
+


### PR DESCRIPTION
The metrics exporter is developed by Percona https://github.com/percona/mongodb_exporter
I have created my own Docker container as there were not official ones.

For the moment the only Prometheus rule for alerting is based on number of members in the replica set. We can extend this in the future if we consider it necessary.

I have also created a dashboard in Grafana displaying some of the metrics scraped.
Closes #129.